### PR TITLE
Add issue intake templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,38 @@
+name: Bug report
+description: Report a bug with reproduction steps and expected behavior.
+title: "[Bug]: "
+labels: ["Feature Bug"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Explain the problem.
+      placeholder: What is broken?
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: Provide the shortest reliable path to reproduce the bug.
+      placeholder: |
+        1. Go to ...
+        2. Click ...
+        3. Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      placeholder: What should happen?
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      placeholder: What happens instead?
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,31 @@
+name: Feature request
+description: Request a feature with clear acceptance criteria.
+title: "[Feature]: "
+labels: ["Feature Bug"]
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: Describe the feature or behavior you want.
+      placeholder: Add a concise description of the requested feature.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance Criteria
+      description: List the conditions that must be true for this issue to be complete.
+      placeholder: |
+        - The user can ...
+        - The UI shows ...
+        - Errors are handled by ...
+    validations:
+      required: true
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes
+      description: Add links, screenshots, or implementation constraints.
+    validations:
+      required: false

--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 This is open issue repo!~
+
+## Issue Intake
+
+Use the GitHub issue templates when opening new work:
+
+- Feature requests should include a short summary and acceptance criteria.
+- Bug reports should include steps to reproduce, expected behavior, and actual behavior.
+
+Clear issue intake makes bounty review easier because maintainers can compare the submitted work against explicit completion criteria.


### PR DESCRIPTION
Closes #9.
Refs #14.

This adds GitHub issue templates for the acceptance-criteria and reproduction-step structure described by the open issues:

- feature request template with required summary and acceptance criteria fields
- bug report template with required steps to reproduce, expected behavior, and actual behavior fields
- short README note explaining the intake flow

Verification:
- `git diff --check`
- `ruby -e 'require "yaml"; Dir[".github/ISSUE_TEMPLATE/*.yml"].each { |f| YAML.load_file(f); puts "valid #{f}" }'`\n\nBounty payout wallet: `0x0f059C4Db3C94633b635aaf2fe3aDd37e01e0a62`