### PR TITLE
docs: add issue intake and interface standards

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
 This is open issue repo!~
+
+## Project Overview
+
+This repository is used to validate the open issue and bounty workflow. It
+keeps a small public surface so maintainers can verify that issue references,
+pull request descriptions, and automatic payout metadata are handled correctly.
+
+## Issue Intake Checklist
+
+Use this checklist when opening or reviewing a feature or bug issue:
+
+- Description: summarize the behavior or interface problem in one sentence.
+- Acceptance Criteria: list the exact conditions that make the issue complete.
+- Steps to Reproduce: include the shortest reproducible path when behavior is
+  broken.
+- Expected Behavior: describe the correct result.
+- Actual Behavior: describe the observed result and any visible error.
+
+## Interface Standard
+
+Interface-related changes should keep labels, layout notes, and visual
+expectations explicit. A valid UI or style issue should mention the affected
+screen, the expected alignment or display rule, and the verification step used
+to confirm the interface now matches the standard.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ pull request descriptions, and automatic payout metadata are handled correctly.
 
 Use this checklist when opening or reviewing a feature or bug issue:
 
+- Feature or Bug: identify whether the request is a feature, behavior bug, or
+  interface issue.
 - Description: summarize the behavior or interface problem in one sentence.
 - Acceptance Criteria: list the exact conditions that make the issue complete.
 - Steps to Reproduce: include the shortest reproducible path when behavior is


### PR DESCRIPTION
## Summary
- Expand the README with a project overview for the open issue workflow.
- Add an issue intake checklist covering feature/bug type, acceptance criteria, reproduction steps, expected behavior, and actual behavior.
- Add interface standards for UI/style issues so display expectations and verification steps are explicit.

## Verification
- git diff --check
- rg -n "Feature or Bug|Acceptance Criteria|Steps to Reproduce|Expected Behavior|Actual Behavior|Interface Standard" README.md

fixes #4
fixes #5
fixes #7
fixes #8
fixes #14
agentpay-wallet: 0xe2e86bdb8753c24032f2ad42b4c1bd9748385a7d
