### PR TITLE
docs: add feature acceptance criteria

### DIFF
--- a/docs/feature-acceptance-criteria.md
+++ b/docs/feature-acceptance-criteria.md
@@ -1,0 +1,29 @@
+# Feature Acceptance Criteria
+
+Use this short checklist when a feature issue needs clear acceptance criteria.
+
+## Required Fields
+
+- Feature summary: one sentence describing the requested behavior.
+- User outcome: the observable result a user or reviewer should see.
+- Acceptance criteria: bullet points that can be checked one by one.
+- Verification: the command, screenshot, or manual path used to confirm the result.
+
+## Review Standard
+
+A feature issue is ready for implementation when every acceptance criterion is:
+
+- Observable from the repository, UI, API response, or documentation.
+- Specific enough that two reviewers would reach the same pass/fail result.
+- Limited to the stated feature scope.
+
+## Example
+
+```markdown
+Feature: Add a visible status label to the issue list.
+
+Acceptance criteria:
+- Each listed issue shows one status label.
+- Empty status values fall back to "unknown".
+- The reviewer can verify the label from the issue list screen.
+```


### PR DESCRIPTION
## Summary
- Add a feature acceptance-criteria guide as a standalone docs file.
- Define required fields, review standards, and a small example for feature issues.

## Verification
- git diff --check
- rg -n "Feature Acceptance Criteria" docs/feature-acceptance-criteria.md

fixes #11
agentpay-wallet: 0xe2e86bdb8753c24032f2ad42b4c1bd9748385a7d
